### PR TITLE
Split plugins because both plugin base classes are loaded mutually ex…

### DIFF
--- a/src/main/java/com/template/plugin/TemplatePlugin.java
+++ b/src/main/java/com/template/plugin/TemplatePlugin.java
@@ -12,21 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-public class TemplatePlugin extends CordaPluginRegistry implements WebServerPluginRegistry {
-    /**
-     * A list of classes that expose web APIs.
-     */
-    private final List<Function<CordaRPCOps, ?>> webApis = ImmutableList.of(TemplateApi::new);
-
-    /**
-     * A list of directories in the resources directory that will be served by Jetty under /web.
-     * The template's web frontend is accessible at /web/template.
-     */
-    private final Map<String, String> staticServeDirs = ImmutableMap.of(
-            // This will serve the templateWeb directory in resources to /web/template
-            "template", getClass().getClassLoader().getResource("templateWeb").toExternalForm()
-    );
-
+public class TemplatePlugin extends CordaPluginRegistry {
     /**
      * Whitelisting the required types for serialisation by the Corda node.
      */

--- a/src/main/java/com/template/plugin/TemplateWebPlugin.java
+++ b/src/main/java/com/template/plugin/TemplateWebPlugin.java
@@ -1,0 +1,37 @@
+package com.template.plugin;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.template.api.TemplateApi;
+import net.corda.core.messaging.CordaRPCOps;
+import net.corda.core.node.CordaPluginRegistry;
+import net.corda.core.serialization.SerializationCustomization;
+import net.corda.webserver.services.WebServerPluginRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class TemplateWebPlugin implements WebServerPluginRegistry {
+    /**
+     * A list of classes that expose web APIs.
+     */
+    @NotNull
+    @Override
+    public List<Function<CordaRPCOps, ? extends Object>> getWebApis() {
+        return ImmutableList.of(TemplateApi::new);
+    }
+
+    /**
+     * A list of directories in the resources directory that will be served by Jetty under /web.
+     * The template's web frontend is accessible at /web/template.
+     */
+    @NotNull
+    @Override
+    public Map<String, String> getStaticServeDirs() {
+        return ImmutableMap.of(
+                // This will serve the templateWeb directory in resources to /web/template
+                "template", getClass().getClassLoader().getResource("templateWeb").toExternalForm());
+    }
+}

--- a/src/main/resources/META-INF/services/net.corda.webserver.services.WebServerPluginRegistry
+++ b/src/main/resources/META-INF/services/net.corda.webserver.services.WebServerPluginRegistry
@@ -1,2 +1,2 @@
 # Register here any CorDapp plugins extending from net.corda.webserver.services.WebServerPluginRegistry.
-com.template.plugin.TemplatePlugin
+com.template.plugin.TemplateWebPlugin


### PR DESCRIPTION
…clusively at runtime.