### PR TITLE
guava libraries reference added to build.gradle, as this template is used in Helloworld Cordaapp

### DIFF
--- a/cordapp-contracts-states/build.gradle
+++ b/cordapp-contracts-states/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     // Corda dependencies.
     cordaCompile "$corda_release_group:corda-core:$corda_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    cordaCompile "com.google.guava:guava:16.0+"
 }


### PR DESCRIPTION
import com.google.common.collect.ImmutableList is used in IOUState.java but there is no reference in build.gradle thus leading to build failure.
Reference Link : https://docs.corda.net/hello-world-state.html