### PR TITLE
Update documentation for running tests with Quasar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ lib/dokka.jar
 *.ipr
 *.iws
 
+# if you use the installQuasar task
+lib
+
 ## Plugin-specific files:
 
 # IntelliJ

--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,6 @@ lib/dokka.jar
 *.ipr
 *.iws
 
-# if you use the installQuasar task
-lib
-
 ## Plugin-specific files:
 
 # IntelliJ
@@ -76,3 +73,6 @@ crashlytics-build.properties
 
 # docs related
 docs/virtualenv/
+
+# if you use the installQuasar task
+lib

--- a/.idea/runConfigurations/Run_Contract_Tests.xml
+++ b/.idea/runConfigurations/Run_Contract_Tests.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Contract Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/contracts" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Run_Flow_Tests.xml
+++ b/.idea/runConfigurations/Run_Flow_Tests.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Flow Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/workflows" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Run_Ingegration_Tests.xml
+++ b/.idea/runConfigurations/Run_Ingegration_Tests.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Ingegration Tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/workflows" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="integrationTest" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -30,24 +30,9 @@ To switch to using the Gradle runner:
 * Set "Delegate IDE build/run actions to gradle" to true
 * Set "Run test using:" to "Gradle Test Runner"
 
-If you would prefer to use the built in IntelliJ JUnit test runner, you can add some code to your ``build.gradle`` file and
-it will copy your quasar JAR file to the lib directory. You will also need to specify ``-javaagent:lib/quasar.jar``
+If you would prefer to use the built in IntelliJ JUnit test runner, you can run ``gradlew installQuasar`` which will
+copy your quasar JAR file to the lib directory. You will then need to specify ``-javaagent:lib/quasar.jar``
 and set the run directory to the project root directory for each test.
-
-Add the following to your ``build.gradle`` file:
-
-```groovy
-    apply plugin: 'net.corda.plugins.quasar-utils'
-
-    task installQuasar(type: Copy) {
-        destinationDir rootProject.file("lib")
-        from(configurations.quasar) {
-            rename 'quasar-core(.*).jar', 'quasar.jar'
-        }
-    }
-```
-
-and then you can run ``gradlew installQuasar``.
 
 ## Running the nodes
 

--- a/README.md
+++ b/README.md
@@ -18,23 +18,36 @@ See https://docs.corda.net/getting-set-up.html.
 
 ## Running tests inside IntelliJ
 	
-We recommend editing your IntelliJ preferences so that you use the gradle runner - this means that the quasar utils 
-plugin will make sure that some flags (like -javaagent - see "Alternatively..." below) are set for you.
+We recommend editing your IntelliJ preferences so that you use the Gradle runner - this means that the quasar utils
+plugin will make sure that some flags (like ``-javaagent`` - see below) are
+set for you.
 
-To switch to using the gradle runner:
+To switch to using the Gradle runner:
 
- * Navigate to `Build, Execution, Deployment -> Build Tools -> Gradle -> Runner` (or search for `runner`)
-   * Windows: this is in "Settings"
-   * MacOS: this is in "Preferences"
- * set "Delegate IDE build/run actions to gradle" to true
- * set "Run test using:" to "Gradle Test Runner"
+* Navigate to ``Build, Execution, Deployment -> Build Tools -> Gradle -> Runner`` (or search for `runner`)
+  * Windows: this is in "Settings"
+  * MacOS: this is in "Preferences"
+* Set "Delegate IDE build/run actions to gradle" to true
+* Set "Run test using:" to "Gradle Test Runner"
 
-Alternatively, to use the built in IntelliJ JUnit test runner, you can:
+If you would prefer to use the built in IntelliJ JUnit test runner, you can add some code to your ``build.gradle`` file and
+it will copy your quasar JAR file to the lib directory. You will also need to specify ``-javaagent:lib/quasar.jar``
+and set the run directory to the project root directory for each test.
 
- * copy your quasar-core.jar to the `<project root>/lib/` dir
-   * this will be the one specified in build.gradle - you can find it in your gradle cache
-     * e.g. on mac/linux you can run something similar to: `find ~/.gradle/caches -name quasar-core\*.jar`
- * for each test specify `-javaagent:lib/quasar-core-<version>.jar` and set the run directory to the project root directory
+Add the following to your ``build.gradle`` file:
+
+```groovy
+    apply plugin: 'net.corda.plugins.quasar-utils'
+
+    task installQuasar(type: Copy) {
+        destinationDir rootProject.file("lib")
+        from(configurations.quasar) {
+            rename 'quasar-core(.*).jar', 'quasar.jar'
+        }
+    }
+```
+
+and then you can run ``gradlew installQuasar``.
 
 ## Running the nodes
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,3 +124,10 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
 }
+
+task installQuasar(type: Copy) {
+    destinationDir rootProject.file("lib")
+    from(configurations.quasar) {
+        rename 'quasar-core(.*).jar', 'quasar.jar'
+    }
+}


### PR DESCRIPTION
Made the quasar related docs essentially identical to the latest corda versions of the same.

Reintroduced gradle runner versions of the run configs.