### PR TITLE
ENT-4880 Prepare template for open core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,9 @@ buildscript {
     ext {
 
         corda_release_group = constants.getProperty("cordaReleaseGroup")
+        corda_core_release_group =  constants.getProperty("cordaCoreReleaseGroup")
         corda_release_version = constants.getProperty("cordaVersion")
+        corda_core_release_version = constants.getProperty("cordaCoreVersion")
         corda_gradle_plugins_version = constants.getProperty("gradlePluginsVersion")
         kotlin_version = constants.getProperty("kotlinVersion")
         junit_version = constants.getProperty("junitVersion")
@@ -75,7 +77,7 @@ sourceSets {
 
 dependencies {
     // Corda dependencies.
-    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaCompile "$corda_release_group:corda-node-api:$corda_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
@@ -87,6 +89,7 @@ dependencies {
     cordaCompile "org.apache.logging.log4j:log4j-web:${log4j_version}"
     cordaCompile "org.slf4j:jul-to-slf4j:$slf4j_version"
 }
+
 cordapp {
     info {
         name "CorDapp Template"
@@ -95,6 +98,7 @@ cordapp {
         minimumPlatformVersion corda_platform_version
     }
 }
+
 task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
     nodeDefaults {
         projectCordapp {

--- a/constants.properties
+++ b/constants.properties
@@ -1,5 +1,7 @@
 cordaReleaseGroup=net.corda
+cordaCoreReleaseGroup=net.corda
 cordaVersion=4.3
+cordaCoreVersion=4.3
 gradlePluginsVersion=5.0.4
 kotlinVersion=1.2.71
 junitVersion=4.12

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -29,7 +29,7 @@ sourceSets {
 
 dependencies {
     // Corda dependencies.
-    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
 }

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testCompile "junit:junit:$junit_version"
 
     // Corda dependencies.
-    cordaCompile "$corda_release_group:corda-core:$corda_release_version"
+    cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"


### PR DESCRIPTION
Update the template to be able to build Enterprise CorDapps against 4.4. with Open Core.
In Corda Enterprise 4.4, the corda-core library will have to be imported from Open Source, so we need a separate depdency group/version for that.