### PR TITLE
ES-1992: Replace deprecated methods with recommended usage

### DIFF
--- a/workflows/src/main/java/com/r3/developers/apples/workflows/RedeemApplesFlow.java
+++ b/workflows/src/main/java/com/r3/developers/apples/workflows/RedeemApplesFlow.java
@@ -78,7 +78,7 @@ public class RedeemApplesFlow implements ClientStartableFlow {
         StateAndRef<AppleStamp> appleStampStateAndRef;
         try {
             appleStampStateAndRef = utxoLedgerService
-                    .findUnconsumedStatesByType(AppleStamp.class)
+                    .findUnconsumedStatesByExactType(AppleStamp.class, 100, Instant.now()).getResults()
                     .stream()
                     .filter(stateAndRef -> stateAndRef.getState().getContractState().getId().equals(stampId))
                     .iterator()
@@ -90,7 +90,7 @@ public class RedeemApplesFlow implements ClientStartableFlow {
         StateAndRef<BasketOfApples> basketOfApplesStampStateAndRef;
         try {
             basketOfApplesStampStateAndRef = utxoLedgerService
-                    .findUnconsumedStatesByType(BasketOfApples.class)
+                    .findUnconsumedStatesByExactType(BasketOfApples.class, 100, Instant.now()).getResults()
                     .stream()
                     .filter(
                             stateAndRef -> stateAndRef.getState().getContractState().getOwner().equals(

--- a/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/GetChatFlow.java
+++ b/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/GetChatFlow.java
@@ -14,6 +14,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.*;
 import static java.util.Objects.*;
 import static java.util.stream.Collectors.toList;
@@ -41,7 +42,7 @@ public class GetChatFlow implements ClientStartableFlow {
         // Note, this code brings all unconsumed states back, then filters them.
         // This is an inefficient way to perform this operation when there are a large number of chats.
         // Note, you will get this error if you input an id which has no corresponding ChatState (common error).
-        List<StateAndRef<ChatState>> chatStateAndRefs = ledgerService.findUnconsumedStatesByType(ChatState.class);
+        List<StateAndRef<ChatState>> chatStateAndRefs = ledgerService.findUnconsumedStatesByExactType(ChatState.class, 100, Instant.now()).getResults();
         List<StateAndRef<ChatState>> chatStateAndRefsWithId = chatStateAndRefs.stream()
                 .filter(sar -> sar.getState().getContractState().getId().equals(flowArgs.getId())).collect(toList());
         if (chatStateAndRefsWithId.size() != 1) throw new CordaRuntimeException("Multiple or zero Chat states with id " + flowArgs.getId() + " found");

--- a/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/ListChatsFlow.java
+++ b/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/ListChatsFlow.java
@@ -11,6 +11,7 @@ import net.corda.v5.ledger.utxo.UtxoLedgerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,7 +34,7 @@ public class ListChatsFlow implements ClientStartableFlow {
         log.info("ListChatsFlow.call() called");
 
         // Queries the VNode's vault for unconsumed states and converts the result to a serializable DTO.
-        List<StateAndRef<ChatState>> states = utxoLedgerService.findUnconsumedStatesByType(ChatState.class);
+        List<StateAndRef<ChatState>> states = utxoLedgerService.findUnconsumedStatesByExactType(ChatState.class, 100, Instant.now()).getResults();
         List<ChatStateResults> results = states.stream().map( stateAndRef ->
             new ChatStateResults(
                     stateAndRef.getState().getContractState().getId(),

--- a/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/UpdateChatFlow.java
+++ b/workflows/src/main/java/com/r3/developers/cordapptemplate/utxoexample/workflows/UpdateChatFlow.java
@@ -58,7 +58,7 @@ public class UpdateChatFlow implements ClientStartableFlow {
             // Note, this code brings all unconsumed states back, then filters them.
             // This is an inefficient way to perform this operation when there are a large number of chats.
             // Note, you will get this error if you input an id which has no corresponding ChatState (common error).
-            List<StateAndRef<ChatState>> chatStateAndRefs = ledgerService.findUnconsumedStatesByType(ChatState.class);
+            List<StateAndRef<ChatState>> chatStateAndRefs = ledgerService.findUnconsumedStatesByExactType(ChatState.class, 100, Instant.now()).getResults();
             List<StateAndRef<ChatState>> chatStateAndRefsWithId = chatStateAndRefs.stream()
                     .filter(sar -> sar.getState().getContractState().getId().equals(flowArgs.getId())).collect(toList());
             if (chatStateAndRefsWithId.size() != 1) throw new CordaRuntimeException("Multiple or zero Chat states with id " + flowArgs.getId() + " found");


### PR DESCRIPTION
CorDapps code includes Corda API methods which were marked as terminally deprecated since 5.0 GA.
When building CPIs, it results in Deprecated warnings in the IDE console.
This change fixes the warnings by using the recommended methods.
Flows were manually tested following the "Running the Chat CorDapp" from Corda 5 documentation.