### PR TITLE
ES-2058: Add Corda container logging configuration

### DIFF
--- a/config/combined-worker-compose.yaml
+++ b/config/combined-worker-compose.yaml
@@ -54,8 +54,14 @@ services:
       - postgresql
       - kafka
       - kafka-create-topics
+    volumes:
+      - ../config:/config
+      - ../logs:/logs
     environment:
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+      LOG4J_CONFIG_FILE: config/log4j2.xml
+      CONSOLE_LOG_LEVEL: info
+      ENABLE_LOG4J2_DEBUG: false
     command: [
       "-mbus.busType=KAFKA",
       "-mbootstrap.servers=kafka:29092",

--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -46,6 +46,7 @@
 
         <root level="debug">
             <AppenderRef ref="App" level="info"/>
+            <AppenderRef ref="Console" level="${env:CONSOLE_LOG_LEVEL:-info}"/>
         </root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
- logs go to both console and files
- console logs are available via `docker logs`
- file logs are at the same location used by CSDE template
- default configurations of logging level and debug logging are provided explicitly, allowing users to modify as needed

All of the above tested locally.

<img width="948" alt="image" src="https://github.com/corda/cordapp-template-java/assets/99472521/ffb6ff9d-034e-429e-8d83-0f2668b1b8c5">
